### PR TITLE
Fix explicit free-list algorithm

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -182,12 +182,17 @@ Block *bestFit(size_t size) {
 
 // Explicit free-list algorithm.
 Block *freeList(size_t size) {
+    Block* foundBlock = nullptr;
     for (const auto &block : free_list) {
-        if (block->size < size) {
-            continue;
+        if (block->size >= size) {
+            foundBlock = block;
+            break;
         }
-        free_list.remove(block);
-        return listAllocate(block, size);
+    }
+
+    if (foundBlock != nullptr) {
+        free_list.remove(foundBlock);
+        return listAllocate(foundBlock, size);
     }
     return nullptr;
 }
@@ -510,10 +515,10 @@ int main(int argc, char const *argv[]) {
     printBlocks();
 
     // TODO: something broken here
-    //auto v2 = alloc(16);
-    //assert(free_list.size() == 0);
-    //assert(getHeader(v1) == getHeader(v2));
-    //printBlocks();
+    auto v2 = alloc(16);
+    assert(free_list.size() == 0);
+    assert(getHeader(v1) == getHeader(v2));
+    printBlocks();
 
 
     // Segregated-fit search


### PR DESCRIPTION
https://gist.github.com/DmitrySoshnikov/e51ebc51a0a27b87cf466a33ce97458c?permalink_comment_id=5007035#gistcomment-5007035

Looks like there is an error in the line 281:

```cpp
free_list.remove(block);
return listAllocate(block, size);
```

Removing element from the list during iteration on the same list - undefined behavour. After execution of `free_list.remove(block) block == NULL` and test on the line 694 fails.

C++ is not my everyday language so I can made a mistake. Here is my fixed version:


```cpp
// Explicit free-list algorithm.
Block *freeList(size_t size) {
    Block* foundBlock = nullptr;
    for (const auto &block : free_list) {
        if (block->size >= size) {
            foundBlock = block;
            break;
        }
    }

    if (foundBlock != nullptr) {
        free_list.remove(foundBlock);
        return listAllocate(foundBlock, size);
    }
    return nullptr;
}
```